### PR TITLE
Updating fstab to internal sharepoint

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,2 +1,2 @@
 mountpoints:
-  /: https://drive.google.com/drive/u/0/folders/1MGzOt7ubUh3gu7zhZIPb7R7dyRzG371j
+  /: https://adobe.sharepoint.com/sites/HelixProjects/Shared%20Documents/sites/caesars/caesars-palace


### PR DESCRIPTION
Fix #2 

🔗 Test URLs:
- Before: https://main--caesars--hlxsites.hlx.page/
- After: https://issue-2-fstab--caesars--hlxsites.hlx.page/

📝 Description:
Updating fstab to point to new sharepoint location