### PR TITLE
Add default padding to all sections

### DIFF
--- a/caesars-palace/blocks/intro-section/intro-section.css
+++ b/caesars-palace/blocks/intro-section/intro-section.css
@@ -1,5 +1,5 @@
 .intro-section.block .intro-section-inner {
-    margin-bottom: 64px;
+    margin-bottom: 8px;
     margin-top: 64px;
     display: flex;
     position: relative;
@@ -49,17 +49,13 @@
 
 @media only screen and (min-width: 960px) {
     .intro-section.block .intro-section-inner {
-        margin-bottom: 120px;
         margin-top: 120px;
+        margin-bottom: 184px;
         align-items: flex-start;
     }
 }
 
 @media only screen and (min-width: 1170px) {
-    .intro-section.block .intro-section-inner {
-        margin-bottom: 20px;
-    }
-
     .intro-section.block .intro-section-content {
         width: 40%;
         margin-right: 64px;

--- a/caesars-palace/styles/styles.css
+++ b/caesars-palace/styles/styles.css
@@ -374,6 +374,14 @@ main .section > div {
   padding: 0 var(--layout-size-m);
 }
 
+main .section > div:first-of-type {
+  padding-top: var(--layout-size-xxl);
+}
+
+main .section > div:last-of-type {
+  padding-bottom: var(--layout-size-xxl);
+}
+
 /* progressive section appearance */
 main .section[data-section-status='loading'],
 main .section[data-section-status='initialized'] {
@@ -388,12 +396,12 @@ main .section.is-hero > div {
   padding: unset;
 }
 
-main .section.has-padding > div:first-of-type {
-  padding-top: var(--layout-size-xxl);
+main .section.compact > div:first-of-type {
+  padding-top: 0;
 }
 
-main .section.has-padding > div:last-of-type {
-  padding-bottom: var(--layout-size-xxl);
+main .section.compact > div:last-of-type {
+  padding-bottom: 0;
 }
 
 main .section.is-hero > div:last-of-type {


### PR DESCRIPTION
Fix #84

## 🔗 Test URLs:
  
- Before: https://main--caesars--hlxsites.hlx.page/caesars-palace/
- After: https://section-padding--caesars--hlxsites.hlx.page/caesars-palace/

## 📝 Description:
  
- the `compact` section style can be used when padding is not desired
