### PR TITLE
Improve empty text handling for dynamic ellipsis

### DIFF
--- a/caesars-palace/blocks/slider/slider.js
+++ b/caesars-palace/blocks/slider/slider.js
@@ -47,7 +47,7 @@ export default function decorate(block) {
     const shortDescriptionDivs = block.querySelectorAll('.short-description');
     shortDescriptionDivs.forEach((div) => {
       const ellipsableText = div.querySelector('p');
-      if(!ellipsableText) return;
+      if (!ellipsableText) return;
 
       const textStyle = window.getComputedStyle(div);
       const textOptions = {
@@ -59,7 +59,7 @@ export default function decorate(block) {
       const textContentWidth = div.offsetWidth - displayBufferPixels;
 
       const fullTextContent = ellipsableText.innerText;
-      if(!fullTextContent) return;
+      if (!fullTextContent) return;
 
       const ellipsisBuilder = buildEllipsis(
         fullTextContent,

--- a/caesars-palace/blocks/slider/slider.js
+++ b/caesars-palace/blocks/slider/slider.js
@@ -59,6 +59,8 @@ export default function decorate(block) {
       const textContentWidth = div.offsetWidth - displayBufferPixels;
 
       const fullTextContent = ellipsableText.innerText;
+      if(!fullTextContent) return;
+
       const ellipsisBuilder = buildEllipsis(
         fullTextContent,
         textContentWidth,

--- a/caesars-palace/blocks/slider/slider.js
+++ b/caesars-palace/blocks/slider/slider.js
@@ -1,4 +1,4 @@
-import { readBlockConfigWithContent } from '../../scripts/scripts.js';
+import { readBlockConfigWithContent, buildEllipsis } from '../../scripts/scripts.js';
 
 const DEFAULT_CONFIG = Object.freeze({
   'visible-slides': 3,
@@ -18,51 +18,6 @@ const getPositionX = (event) => (event.type.includes('mouse')
 const setSliderPosition = (currentTranslate, slider) => {
   slider.style.transform = `translateX(${currentTranslate}px)`;
 };
-
-/**
- * Build the preview of a text with ellipsis
- * @param {String} text Text that will be shortened
- * @param {Integer} width Width of container
- * @param {Integer} maxVisibleLines Max visible lines allowed
- * @param {*} suffix Suffix to use for ellipsis
- *  (will make sure text+ellipsis fit in `maxVisibleLines`)
- * @param {*} options Text styling option
- *
- * @return The ellipsed text (without ellipsis suffix)
- */
-function buildEllipsis(text, width, maxVisibleLines, suffix, options = {}) {
-  const canvas = buildEllipsis.canvas || (buildEllipsis.canvas = document.createElement('canvas'));
-  const context = canvas.getContext('2d');
-  Object.entries(options).forEach(([key, value]) => {
-    if (key in context) {
-      context[key] = value;
-    }
-  });
-
-  const words = text.split(' ');
-  let testLine = '';
-  let lineCount = 1;
-
-  let shortText = '';
-
-  words.forEach((w, index) => {
-    testLine += `${w} `;
-    const { width: testWidth } = context.measureText(`${testLine}${suffix}`);
-    if (testWidth > width && index > 0) {
-      lineCount += 1;
-      testLine = `${w} `;
-    }
-
-    if (lineCount <= maxVisibleLines) {
-      shortText += `${w} `;
-    }
-  });
-
-  return {
-    lineCount,
-    shortText,
-  };
-}
 
 export default function decorate(block) {
   const blockConfig = { ...DEFAULT_CONFIG, ...readBlockConfigWithContent(block) };
@@ -92,6 +47,8 @@ export default function decorate(block) {
     const shortDescriptionDivs = block.querySelectorAll('.short-description');
     shortDescriptionDivs.forEach((div) => {
       const ellipsableText = div.querySelector('p');
+      if(!ellipsableText) return;
+
       const textStyle = window.getComputedStyle(div);
       const textOptions = {
         font: `${textStyle.fontWeight} ${textStyle.fontSize} ${textStyle.fontFamily}`,

--- a/caesars-palace/scripts/scripts.js
+++ b/caesars-palace/scripts/scripts.js
@@ -137,7 +137,6 @@ export function readBlockConfigWithContent(block) {
       configObj[key] = Number(value);
     }
   });
-
   return configObj;
 }
 

--- a/caesars-palace/scripts/scripts.js
+++ b/caesars-palace/scripts/scripts.js
@@ -137,6 +137,7 @@ export function readBlockConfigWithContent(block) {
       configObj[key] = Number(value);
     }
   });
+
   return configObj;
 }
 


### PR DESCRIPTION
<!--- Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after): -->

Fix handling of "no text" case for ellipsis.

## 🔗 Test URLs:
  
- Before: https://main--caesars--hlxsites.hlx.page/caesars-palace/
- After: https://rewards--caesars--hlxsites.hlx.page/caesars-palace/

## 📝 Description:
  
<!--- What changes are in this pull request? Include screenshots when helpful. -->
- Improve handling of "no text" case for ellipsis building.