### PR TITLE
Fix event listener not being properly removed in header

### DIFF
--- a/caesars-palace/blocks/header/header.js
+++ b/caesars-palace/blocks/header/header.js
@@ -144,6 +144,10 @@ export default async function decorate(block) {
   const globalNavSection = document.createElement('div');
   globalNavSection.classList.add('global-nav-section');
 
+  const globalNavTitleClickHandler = () => {
+    toggleNavSectionTitles(globalNavTitle, globalNavSections);
+  };
+
   // fetch global nav
   if (window.location.host.endsWith('.page') || window.location.host.endsWith('.live') || window.location.host.startsWith('localhost')) {
     globalNav = await fetch(`${GLOBAL_HEADER_JSON_LOCAL}`);
@@ -178,9 +182,7 @@ export default async function decorate(block) {
       globalNavSection.appendChild(globalNavLinks);
       globalNavDesktop.appendChild(globalNavSection);
       globalNavSections = globalNavDiv;
-      globalNavTitle.addEventListener('click', () => {
-        toggleNavSectionTitles(globalNavTitle, globalNavSections);
-      });
+      globalNavTitle.addEventListener('click', globalNavTitleClickHandler);
     }
     if (globalNavJson.logoFileReference) {
       globalNavDesktop.prepend(await createGlobalNavLogo(globalNavJson.logoFileReference));
@@ -245,14 +247,16 @@ export default async function decorate(block) {
       const localNavTitle = block.querySelector('.local-nav-title');
       const globalNavTitle = block.querySelector('.global-nav-title');
       toggleMenu(nav, navSections, isDesktop.matches);
+
+      const localNavTitleEventHandler = () => {
+        toggleNavSectionTitles(localNavTitle, localNavTitle.parentElement());
+        toggleNavSectionTitles(globalNavTitle, globalNavTitle.parentElement());
+      };
       if (isDesktop.matches) {
-        localNavTitle.removeEventListener('click');
-        globalNavTitle.removeEventListener('click');
+        localNavTitle.removeEventListener('click', localNavTitleEventHandler);
+        globalNavTitle.removeEventListener('click', globalNavTitleClickHandler);
       } else {
-        localNavTitle.addEventListener('click', () => {
-          toggleNavSectionTitles(localNavTitle, localNavTitle.parentElement());
-          toggleNavSectionTitles(globalNavTitle, globalNavTitle.parentElement());
-        });
+        localNavTitle.addEventListener('click', localNavTitleEventHandler);
       }
     });
 


### PR DESCRIPTION
<!--- Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after): -->

Fix event listener not being properly removed in header when resizing the window:
<img width="1619" alt="Screenshot 2023-03-30 at 1 58 34 PM" src="https://user-images.githubusercontent.com/60901087/228963164-f2aa8404-22f3-43a4-8c60-528a26aa1fb4.png">


## 🔗 Test URLs:
  
- Before: https://main--caesars--hlxsites.hlx.page/caesars-palace/
- After: https://non-carousel-current-optimizations--caesars--hlxsites.hlx.page/caesars-palace/

## 📝 Description:
  
<!--- What changes are in this pull request? Include screenshots when helpful. -->
- Fix event listener not being properly removed in header when resizing the window (size down and up again the window using the mouse to see the bug happen in the old version and verify it isn't happening in the fixed one).