### PR TITLE
Issue151-Button Edge case broken

### DIFF
--- a/caesars-palace/scripts/lib-franklin.js
+++ b/caesars-palace/scripts/lib-franklin.js
@@ -484,17 +484,13 @@ export function decorateButtons(element) {
       const up = a.parentElement;
       const twoup = a.parentElement.parentElement;
       if (!a.querySelector('img')) {
-        if (up.childNodes.length === 1 && (up.tagName === 'P' || up.tagName === 'DIV')) {
-          a.className = 'button primary'; // default
+        if (up.tagName === 'P' || up.tagName === 'DIV') { // Regular link decoration
+          a.className = 'button primary';
           up.classList.add('button-container');
-        }
-        if (up.childNodes.length === 1 && up.tagName === 'STRONG'
-          && twoup.childNodes.length === 1 && twoup.tagName === 'P') {
+        } else if (up.tagName === 'STRONG' && twoup.tagName === 'P') { // Bolded link decoration
           a.className = 'button primary';
           twoup.classList.add('button-container');
-        }
-        if (up.childNodes.length === 1 && up.tagName === 'EM'
-          && twoup.childNodes.length === 1 && twoup.tagName === 'P') {
+        } else if (up.tagName === 'EM' && twoup.tagName === 'P') { // Italicized link decoration
           a.className = 'button secondary';
           twoup.classList.add('button-container');
         }


### PR DESCRIPTION
Fix #151

## 🔗 Test URLs:
  
- Before: https://main--caesars--hlxsites.hlx.page/caesars-palace/drafts/AuthoringGuide/authoringguide-buttons
- After:[ https://<branch>--caesars--hlxsites.hlx.page/caesars-palace/](https://issue-151-buttonedgecasebroken--caesars--hlxsites.hlx.page/caesars-palace/drafts/AuthoringGuide/authoringguide-buttons)

## 📝 Description:
 Eased decoration restrictions to allow for edge case needed where buttons are not the only child (more than 1 in a line/paragraph/div) 
 
Switched to else if to avoid extra unnecessary condition checking 

