### PR TITLE
Slider: Hide h5 substitles when long text is displayed

### DIFF
--- a/caesars-palace/blocks/slider/slider.css
+++ b/caesars-palace/blocks/slider/slider.css
@@ -97,6 +97,10 @@
   display: none;
 }
 
+.slider .extended-text h5 {
+  display: none;
+}
+
 .slider .card .short-description h4 {
   text-transform: uppercase;
   line-height: 1.1;


### PR DESCRIPTION
<!--- Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after): -->

Fix #<gh-issue-id>

## 🔗 Test URLs:
  
- Before: https://main--caesars--hlxsites.hlx.page/caesars-palace/restaurants/forum-food-hall
- After: https://foods-css-fixes--caesars--hlxsites.hlx.page/caesars-palace/restaurants/forum-food-hall

## 📝 Description:
  
<!--- What changes are in this pull request? Include screenshots when helpful. -->
- Hide card subtitle when the extended text is opened.
