### PR TITLE
text overlay controlled by author

### DIFF
--- a/caesars-palace/blocks/product-details/product-details.js
+++ b/caesars-palace/blocks/product-details/product-details.js
@@ -272,6 +272,7 @@ export default async function decorate(block) {
           const colImage = row.Image;
           const buttonTitle = row['Button Title'];
           const buttonLink = row['Button Link'];
+          const textOverlay = row['Text Overlay'];
 
           if (colTitle && colDesc && colImage) {
             // Create the content structure
@@ -294,18 +295,13 @@ export default async function decorate(block) {
               columnsSection.classList.add('section', 'has-centered-text');
               columnsSection.append(columnsBlock);
               main.append(columnsSection);
-            } else if (i % 2 === 0) {
-              // Even rows
-              const columnsBlock = buildBlock('columns', [[colPicture, contentDiv]]);
-              columnsBlock.classList.add('cet-card', 'full-width');
-              // Add these elements to a new section
-              const columnsSection = document.createElement('div');
-              columnsSection.classList.add('section', 'has-centered-text');
-              columnsSection.append(columnsBlock);
-              main.append(columnsSection);
             } else {
-              // Odd rows
-              const columnsBlock = buildBlock('columns', [[contentDiv, colPicture]]);
+              let columnsBlock;
+              if (textOverlay && textOverlay.toLowerCase() === 'right') {
+                columnsBlock = buildBlock('columns', [[colPicture, contentDiv]]);
+              } else {
+                columnsBlock = buildBlock('columns', [[contentDiv, colPicture]]);
+              }
               columnsBlock.classList.add('cet-card', 'full-width');
               // Add these elements to a new section
               const columnsSection = document.createElement('div');


### PR DESCRIPTION

Fix #184 

## 🔗 Test URLs:
  
- Before: https://main--caesars--hlxsites.hlx.page/caesars-palace/drafts/amol/hells-kitchen
- After: https://issue-184-text-overlay--caesars--hlxsites.hlx.page/caesars-palace/drafts/amol/hells-kitchen

## 📝 Description:
  
Used to be automated. Caesars wants to control whether the text is on the left or right based on author input which will be in a separate column called 'Text Overlay' and they add the word 'Right' or 'right' to the cell and it will push the content right and if empty then it will default the content to the left.