### PR TITLE
using relative links for product details pages

### DIFF
--- a/caesars-palace/blocks/card-list/card-list.js
+++ b/caesars-palace/blocks/card-list/card-list.js
@@ -508,7 +508,14 @@ function createCard(cardData, index, cfg) {
   if (cfg.filters) {
     processFiltersWithCard(cardData, card, cfg.filters);
   }
-  const cardLink = cardData['Page URL'] !== '' ? cardData['Page URL'] : cardData['Secondary Link'];
+
+  let pageUrl = cardData['Page URL'];
+  if (pageUrl) {
+    const pageUrlObj = new URL(pageUrl);
+    pageUrl = pageUrlObj.pathname;
+  }
+  const cardLink = pageUrl !== '' ? pageUrl : cardData['Secondary Link'];
+
   // card image
   const cardImage = document.createElement('div');
   cardImage.classList.add('card-image');


### PR DESCRIPTION

Fix #224 

## 🔗 Test URLs:
  
- Before: https://main--caesars--hlxsites.hlx.page/caesars-palace/restaurants
- After: https://update-card-list-links--caesars--hlxsites.hlx.page/caesars-palace/restaurants

## 📝 Description:
  
updating links to be relative