### PR TITLE
Add badge to product block (page)

### DIFF
--- a/caesars-palace/blocks/product-details/product-details.js
+++ b/caesars-palace/blocks/product-details/product-details.js
@@ -35,6 +35,7 @@ export default async function decorate(block) {
       const heroImage = overview['Hero Image'];
       const heroVideo = overview['Hero Video'];
       const heroTitle = overview['Hero Title'];
+      const heroBadge = overview['Hero Badge'];
       const heroTitleAdd = overview['Hero Title Add'];
       const heroSubtitle = overview['Hero Subtitle'];
       const openTableEmbed = overview['Opentable Widget Link'];
@@ -72,6 +73,11 @@ export default async function decorate(block) {
           const picture = createOptimizedPicture(`${heroImage}`, heroTitle, true);
           heroSection.classList.add('has-background');
           heroSection.append(picture);
+        }
+        if(heroBadge) {
+          const heroBadgePicture = createOptimizedPicture(`${heroBadge}`, heroTitle, true);
+          const heroBadgeBlock = buildBlock('overlay-logo', [[heroBadgePicture]]);
+          heroSection.append(heroBadgeBlock);
         }
         const heroH1 = createTag('h1', {}, heroTitle);
         // Add the elements to the section

--- a/caesars-palace/blocks/product-details/product-details.js
+++ b/caesars-palace/blocks/product-details/product-details.js
@@ -71,6 +71,9 @@ export default async function decorate(block) {
           heroSection.append(videoBlock);
         } else if (heroImage && !heroVideo) {
           const picture = createOptimizedPicture(`${heroImage}`, heroTitle, true);
+          picture.querySelectorAll('img').forEach((image) => {
+            image.loading = 'eager';
+          });
           heroSection.classList.add('has-background');
           heroSection.append(picture);
         }

--- a/caesars-palace/blocks/product-details/product-details.js
+++ b/caesars-palace/blocks/product-details/product-details.js
@@ -71,9 +71,6 @@ export default async function decorate(block) {
           heroSection.append(videoBlock);
         } else if (heroImage && !heroVideo) {
           const picture = createOptimizedPicture(`${heroImage}`, heroTitle, true);
-          picture.querySelectorAll('img').forEach((image) => {
-            image.loading = 'eager';
-          });
           heroSection.classList.add('has-background');
           heroSection.append(picture);
         }

--- a/caesars-palace/blocks/product-details/product-details.js
+++ b/caesars-palace/blocks/product-details/product-details.js
@@ -74,7 +74,7 @@ export default async function decorate(block) {
           heroSection.classList.add('has-background');
           heroSection.append(picture);
         }
-        if(heroBadge) {
+        if (heroBadge) {
           const heroBadgePicture = createOptimizedPicture(`${heroBadge}`, heroTitle, true);
           const heroBadgeBlock = buildBlock('overlay-logo', [[heroBadgePicture]]);
           heroSection.append(heroBadgeBlock);


### PR DESCRIPTION
<!--- Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after): -->

Fix missing badge on product page

## 🔗 Test URLs:
  
- Before: https://main--caesars--hlxsites.hlx.page/caesars-palace/drafts/structured-content/restaurants/gordon-ramsey-pub-and-grill
- After: https://add-badge-to-product-page--caesars--hlxsites.hlx.page/caesars-palace/drafts/structured-content/restaurants/gordon-ramsey-pub-and-grill

## 📝 Description:
  
<!--- What changes are in this pull request? Include screenshots when helpful. -->
- Adds a badge to a product badge if there is a 'Hero Badge' column in the Excel (content of the column is the link to the image to use as badge).